### PR TITLE
feat: auto containerd detection

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -39,7 +39,8 @@ export function App() {
   const [totalOutput, setTotalOutput] = useState("");
   const [actualImageTag, setActualImageTag] = useState("");
   const [errorText, setErrorText] = useState("");
-  const [useContainerdChecked, setUseContainerdChecked] = React.useState(false);
+  const [useContainerdChecked, setUseContainerdChecked] = useState(false);
+  const [jsonFileName, setJsonFileName] = useState("default");
 
 
   const [inSettings, setInSettings] = useState(false);
@@ -49,7 +50,19 @@ export function App() {
   const [showFailure, setShowFailure] = useState(false);
   const [showCopaOutputModal, setShowCopaOutputModal] = useState(false);
   const [showCommandLine, setShowCommandLine] = useState(false);
-  
+  useEffect(() => {
+    const checkForContainerd = async () => {
+      let containerdEnabled = await isContainerdEnabled();
+      setUseContainerdChecked(containerdEnabled);
+    }
+    checkForContainerd();
+  }, []);
+
+  useEffect(() => {
+    if (finishedScan) {
+      triggerCopa();
+    }
+  }, [finishedScan]);
 
   const patchImage = () => {
     setShowPreload(false);
@@ -111,6 +124,16 @@ export function App() {
       ({ stdout, stderr } = await runCopa(commandParts, stdout, stderr));
     }
   }
+
+  async function isContainerdEnabled() {
+    const result = await ddClient.docker.cli.exec("info", [
+      "--format",
+      '"{{ json . }}"',
+    ]);
+    const info = JSON.parse(result.stdout);
+    return info.Driver === "overlayfs";
+  }
+
 
   async function runCopa(commandParts: string[], stdout: string, stderr: string) {
     let latestStderr: string = "";

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -58,12 +58,6 @@ export function App() {
     checkForContainerd();
   }, []);
 
-  useEffect(() => {
-    if (finishedScan) {
-      triggerCopa();
-    }
-  }, [finishedScan]);
-
   const patchImage = () => {
     setShowPreload(false);
     setShowLoading(true);

--- a/ui/src/copainput.tsx
+++ b/ui/src/copainput.tsx
@@ -101,47 +101,44 @@ export function CopaInput(props: any) {
     <Stack spacing={2}>
       <Stack>
         <Stack direction="row" alignItems="center" spacing={2}>
-      <Autocomplete
-        freeSolo
-        disablePortal
-        value={props.selectedImage}
-        onInputChange={(event: any, newValue: string | null) => {
-          props.setSelectedImage(newValue);
-          if (newValue !== null) { 
-            const seperateSplit = newValue?.split(':');
-            const numColons = seperateSplit.length - 1;
-            if (numColons === 0) { 
-              props.setImageName(newValue + ":latest");
-            } else {
-              props.setImageName(newValue);
-            }
-          }
-        }}
-        id="image-select-combo-box"
-        options={dockerImages}
-        sx={{ width: 300 }}
-        renderInput={(params) =>
-          <TextField
-            {...params}
-            label={selectImageLabel}
-            error={selectedImageError}
+          <Autocomplete
+            freeSolo
+            disablePortal
+            value={props.selectedImage}
+            onInputChange={(event: any, newValue: string | null) => {
+              props.setSelectedImage(newValue);
+              if (newValue !== null) {
+                const seperateSplit = newValue?.split(':');
+                const numColons = seperateSplit.length - 1;
+                if (numColons === 0) {
+                  props.setImageName(newValue + ":latest");
+                } else {
+                  props.setImageName(newValue);
+                }
+              }
+            }}
+            id="image-select-combo-box"
+            options={dockerImages}
+            sx={{ width: 300 }}
+            renderInput={(params) =>
+              <TextField
+                {...params}
+                label={selectImageLabel}
+                error={selectedImageError}
                 helperText={!props.useContainerdChecked &&
-                  <Stack direction="row" alignItems="center">
+                  <Stack direction="row" alignItems="center" spacing={1.05}>
                     <Tooltip title={"Enable containerd image store to patch "
                       + "local images (i.e. built or tagged locally but not pushed to a registry)."}>
-                      <IconButton
-                        onClick={() => {
-                          ddClient.host.openExternal("https://docs.docker.com/desktop/containerd/")
-                        }}
-                        size='small'
-                      >
-                        <InfoIcon fontSize='inherit' />
-                      </IconButton>
+                      <InfoIcon fontSize='small' />
                     </Tooltip>
-                    <Typography variant='caption'>Containerd image store not enabled</Typography>
+                    <Link href="#" onClick={() => {
+                      ddClient.host.openExternal("https://docs.docker.com/desktop/containerd/")
+                    }}>
+                      <Typography variant='caption'>Containerd image store not enabled</Typography>
+                    </Link>
                   </Stack>}
-          />}
-      />
+              />}
+          />
         </Stack>
       </Stack>
       <FormControl fullWidth>

--- a/ui/src/copainput.tsx
+++ b/ui/src/copainput.tsx
@@ -99,6 +99,8 @@ export function CopaInput(props: any) {
 
   return (
     <Stack spacing={2}>
+      <Stack>
+        <Stack direction="row" alignItems="center" spacing={2}>
       <Autocomplete
         freeSolo
         disablePortal
@@ -123,9 +125,25 @@ export function CopaInput(props: any) {
             {...params}
             label={selectImageLabel}
             error={selectedImageError}
-            helperText={selectedImageHelperText}
+                helperText={!props.useContainerdChecked &&
+                  <Stack direction="row" alignItems="center">
+                    <Tooltip title={"Turn on if using containerd image store, which allows patching of "
+                      + "local images (i.e. built or tagged locally but not pushed to a registry)."}>
+                      <IconButton
+                        onClick={() => {
+                          ddClient.host.openExternal("https://docs.docker.com/desktop/containerd/")
+                        }}
+                        size='small'
+                      >
+                        <InfoIcon fontSize='inherit' />
+                      </IconButton>
+                    </Tooltip>
+                    <Typography variant='caption'>Containerd image store not enabled</Typography>
+                  </Stack>}
           />}
       />
+        </Stack>
+      </Stack>
       <FormControl fullWidth>
         <InputLabel id="demo-simple-select-label" variant='outlined'>Scanner</InputLabel>
         <Select

--- a/ui/src/copainput.tsx
+++ b/ui/src/copainput.tsx
@@ -127,7 +127,7 @@ export function CopaInput(props: any) {
             error={selectedImageError}
                 helperText={!props.useContainerdChecked &&
                   <Stack direction="row" alignItems="center">
-                    <Tooltip title={"Turn on if using containerd image store, which allows patching of "
+                    <Tooltip title={"Enable containerd image store to patch "
                       + "local images (i.e. built or tagged locally but not pushed to a registry)."}>
                       <IconButton
                         onClick={() => {

--- a/ui/src/copainput.tsx
+++ b/ui/src/copainput.tsx
@@ -177,22 +177,6 @@ export function CopaInput(props: any) {
                 props.setSelectedTimeout(event.target.value);
               }}
             />
-            <Stack direction="row">
-              <FormControlLabel control={
-                <Switch
-                  checked={props.useContainerdChecked}
-                  onChange={handleLocalImageSwitchChecked}
-                />
-              } label="Using containerd image store" />
-              <Tooltip title={"Turn on if using containerd image store, which allows patching of "
-                + "local images (i.e. built or tagged locally but not pushed to a registry)."}>
-                <IconButton onClick={() => {
-                  ddClient.host.openExternal("https://docs.docker.com/desktop/containerd/")
-                }}>
-                  <InfoIcon />
-                </IconButton>
-              </Tooltip>
-            </Stack>
           </Stack>
         </Grow>
       </Collapse>


### PR DESCRIPTION
- Added a new function "isContainerdEnabled" that uses the "docker info" command to determine if the user has containerd image store enabled
- Removed switch in the settings section to tell the extension if containerd is enabled
- Added helper text to the image selection component that appears if containerd isn't enabled
- Added a tooltip that explains that enabling containerd lets the user patch local images
- Moved the containerd documentation link to the text instead of the info icon