### PR TITLE
fix: textbox bug with patched image name

### DIFF
--- a/ui/src/copainput.tsx
+++ b/ui/src/copainput.tsx
@@ -107,15 +107,6 @@ export function CopaInput(props: any) {
             value={props.selectedImage}
             onInputChange={(event: any, newValue: string | null) => {
               props.setSelectedImage(newValue);
-              if (newValue !== null) {
-                const seperateSplit = newValue?.split(':');
-                const numColons = seperateSplit.length - 1;
-                if (numColons === 0) {
-                  props.setImageName(newValue + ":latest");
-                } else {
-                  props.setImageName(newValue);
-                }
-              }
             }}
             id="image-select-combo-box"
             options={dockerImages}


### PR DESCRIPTION
- Added new function, getImageTag, to calculate the correct tag for the patched image during a render.
- Removed state variable imageName, which was a previous attempt at fixing the bug
- Removed calculation of imageName in the onInputChange for the image autocomplete
- Removed actualImageTag state variable
- Removed image tag calculation from the triggerCopa function, because this is handled by getImageTag

**Closes:** #12 