### PR TITLE
fix: changed image name from copacetic/ to projectcopacetic/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE?=copacetic/copacetic-docker-desktop-extension
+IMAGE?=projectcopacetic/copacetic-docker-desktop-extension
 TAG?=0.1.0
 COPA_VERSION?=latest
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This extension is a web application displayed in a tab of the dashboard in Docke
 The extension be installed using this link! It can also be installed with the following command:
 
 ```
-docker extension install copacetic/copacetic-docker-desktop-extension:0.1.0
+docker extension install projectcopacetic/copacetic-docker-desktop-extension:0.1.0
 ```
 
 ## Contributing


### PR DESCRIPTION
- Changed image name from "copacetic/copacetic-docker-desktop-extension:0.1.0" to "projectcopacetic/copacetic-docker-desktop-extension:0.1.0" in README.md and Makefile