### PR TITLE
feat: add new flags and UI controls for v0.12.0 features

### DIFF
--- a/container/copa-extension/entrypoint.sh
+++ b/container/copa-extension/entrypoint.sh
@@ -9,6 +9,15 @@ timeout=$4
 connection_format=$5
 format=$6
 output_file=$7
+push_flag=$8
+exit_on_eol=$9
+eol_api_url=${10}
+platform=${11}
+ignore_errors=${12}
+progress=${13}
+oci_dir=${14}
+pkg_types=${15}
+library_patch_level=${16}
 
 # parse image into image name
 image_no_tag=$(echo "$image" | cut -d':' -f1)
@@ -39,8 +48,60 @@ case "$connection_format" in
     ;;
 esac
 
+# build optional flags
+optional_flags=""
+
+# add push flag if enabled
+if [ "$push_flag" = "true" ]; then
+    optional_flags="$optional_flags --push"
+fi
+
+# add exit-on-eol flag if enabled
+if [ "$exit_on_eol" = "true" ]; then
+    optional_flags="$optional_flags --exit-on-eol"
+fi
+
+# add eol-api-url if provided
+if [ -n "$eol_api_url" ] && [ "$eol_api_url" != "default" ]; then
+    optional_flags="$optional_flags --eol-api-url=$eol_api_url"
+fi
+
+# add platform if provided
+if [ -n "$platform" ] && [ "$platform" != "all" ]; then
+    optional_flags="$optional_flags --platform=$platform"
+fi
+
+# add ignore-errors flag if enabled
+if [ "$ignore_errors" = "true" ]; then
+    optional_flags="$optional_flags --ignore-errors"
+fi
+
+# add progress flag if provided
+if [ -n "$progress" ] && [ "$progress" != "auto" ]; then
+    optional_flags="$optional_flags --progress=$progress"
+fi
+
+# add oci-dir flag if provided (v0.12.0)
+if [ -n "$oci_dir" ]; then
+    optional_flags="$optional_flags --oci-dir=$oci_dir"
+fi
+
+# add pkg-types flag if not default (v0.12.0)
+if [ -n "$pkg_types" ] && [ "$pkg_types" != "os" ]; then
+    optional_flags="$optional_flags --pkg-types=$pkg_types"
+fi
+
+# add library-patch-level flag if library patching is enabled (v0.12.0)
+if [ "$pkg_types" = "library" ] || [ "$pkg_types" = "os,library" ]; then
+    if [ -n "$library_patch_level" ] && [ "$library_patch_level" != "patch" ]; then
+        optional_flags="$optional_flags --library-patch-level=$library_patch_level"
+    fi
+    # Set experimental flag for app-level patching
+    export COPA_EXPERIMENTAL=1
+fi
+
 # run copa to patch image
-if copa patch -i $image -r output/"$report" -t "$patched_tag" $connection --timeout $timeout $output;
+if copa patch -i $image -r output/"$report" -t "$patched_tag" $connection --timeout $timeout $output $optional_flags;
 then
     patched_image="$image_no_tag:$patched_tag"
     echo "patched-image=$patched_image"

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -56,7 +56,20 @@ export function App() {
   const [totalOutput, setTotalOutput] = useState("");
   const [errorText, setErrorText] = useState("");
   const [useContainerdChecked, setUseContainerdChecked] = useState(false);
-  const [latestCopaVersion, setLatestCopaVerison] = useState("v0.7.0");
+  const [latestCopaVersion, setLatestCopaVerison] = useState("v0.12.0");
+
+  // New flags for v0.11.1+ features
+  const [pushToRegistry, setPushToRegistry] = useState<boolean>(false);
+  const [exitOnEol, setExitOnEol] = useState<boolean>(false);
+  const [eolApiUrl, setEolApiUrl] = useState<string>("default");
+  const [selectedPlatform, setSelectedPlatform] = useState<string>("all");
+  const [ignoreErrors, setIgnoreErrors] = useState<boolean>(false);
+  const [progressMode, setProgressMode] = useState<string>("auto");
+
+  // New flags for v0.12.0 features
+  const [ociDir, setOciDir] = useState<string>("");
+  const [pkgTypes, setPkgTypes] = useState<string>("os");
+  const [libraryPatchLevel, setLibraryPatchLevel] = useState<string>("patch");
 
   const [inSettings, setInSettings] = useState(false);
   const [showPreload, setShowPreload] = useState(true);
@@ -143,6 +156,15 @@ export function App() {
     setSelectedScanner("trivy");
     setSelectedImageTag("");
     setSelectedTimeout("5m");
+    setPushToRegistry(false);
+    setExitOnEol(false);
+    setEolApiUrl("default");
+    setSelectedPlatform("all");
+    setIgnoreErrors(false);
+    setProgressMode("auto");
+    setOciDir("");
+    setPkgTypes("os");
+    setLibraryPatchLevel("patch");
     setVulnerabilityCount({
       "UNKNOWN": 0,
       "LOW": 0,
@@ -194,9 +216,11 @@ export function App() {
       `${TRIVY_CONTAINER_NAME}`,
       "aquasec/trivy",
       "image",
-      "--vuln-type",
-      "os",
+      "--pkg-types",
+      pkgTypes,  // Use dynamic package types (os, library, or os,library)
       "--ignore-unfixed",
+      "--scanners",
+      "vuln",
       "--format",
       "json",
       "-o",
@@ -243,7 +267,17 @@ export function App() {
         `${getImageTag()}`,
         `${selectedTimeout === undefined ? "5m" : selectedTimeout}`,
         `${useContainerdChecked ? 'custom-socket' : 'buildx'}`,
-        "openvex"
+        "openvex",
+        "",  // output_file (empty for now)
+        `${pushToRegistry}`,
+        `${exitOnEol}`,
+        `${eolApiUrl}`,
+        `${selectedPlatform}`,
+        `${ignoreErrors}`,
+        `${progressMode}`,
+        `${ociDir}`,  // v0.12.0: OCI directory
+        `${pkgTypes}`,  // v0.12.0: Package types
+        `${libraryPatchLevel}`  // v0.12.0: Library patch level
       ];
       ({ stdout, stderr } = await runCopa(commandParts, stdout, stderr));
     }
@@ -494,6 +528,24 @@ export function App() {
             getTrivyOutput={getTrivyOutput}
             vulnState={vulnState}
             setVulnState={setVulnState}
+            pushToRegistry={pushToRegistry}
+            setPushToRegistry={setPushToRegistry}
+            exitOnEol={exitOnEol}
+            setExitOnEol={setExitOnEol}
+            eolApiUrl={eolApiUrl}
+            setEolApiUrl={setEolApiUrl}
+            selectedPlatform={selectedPlatform}
+            setSelectedPlatform={setSelectedPlatform}
+            ignoreErrors={ignoreErrors}
+            setIgnoreErrors={setIgnoreErrors}
+            progressMode={progressMode}
+            setProgressMode={setProgressMode}
+            ociDir={ociDir}
+            setOciDir={setOciDir}
+            pkgTypes={pkgTypes}
+            setPkgTypes={setPkgTypes}
+            libraryPatchLevel={libraryPatchLevel}
+            setLibraryPatchLevel={setLibraryPatchLevel}
           />}
         {showLoading && loadingPage}
         {showSuccess && successPage}

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,7 +1,6 @@
 // src/App.tsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
-  Autocomplete,
   Button,
   Box,
   Stack,
@@ -9,16 +8,8 @@ import {
   Divider,
   Link,
   CircularProgress,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
   IconButton,
-  Grow,
   Collapse,
-  Paper,
-  LinearProgress
 } from '@mui/material';
 import { createDockerDesktopClient } from '@docker/extension-api-client';
 import { CopaInput } from './copainput';
@@ -45,8 +36,6 @@ export function App() {
   const learnMoreLink = "https://project-copacetic.github.io/copacetic/website/";
 
   const ddClient = createDockerDesktopClient();
-  // The correct image name of the currently selected image. The latest tag is added if there is no tag.
-  const [imageName, setImageName] = useState("");
 
 
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
@@ -92,35 +81,76 @@ export function App() {
   });
 
   const getTrivyOutput = async () => {
+    try {
+      // Clean up any existing busybox container first
+      await ddClient.docker.cli.exec("rm", [
+        "-f",
+        `${BUSYBOX_CONTAINER_NAME}`
+      ]);
 
-    const output = await ddClient.docker.cli.exec("run", [
-      "-v",
-      "copa-extension-volume:/data",
-      "--name",
-      `${BUSYBOX_CONTAINER_NAME}`,
-      "busybox",
-      "cat",
-      `data/${JSON_FILE_NAME}`
-    ]);
-    const data = JSON.parse(output.stdout);
-    const severityMap: Record<string, number> = {
-      "UNKNOWN": 0,
-      "LOW": 0,
-      "MEDIUM": 0,
-      "HIGH": 0,
-      "CRITICAL": 0
-    };
-    if (data.Results) {
-      for (const result of data.Results) {
-        if (result.Vulnerabilities) {
-          for (const vulnerability of result.Vulnerabilities) {
-            severityMap[vulnerability.Severity]++;
+      // Read the scan file in chunks and process in JavaScript
+      // This is the ONLY way that works with the Docker Extension SDK restrictions
+      const severityMap: Record<string, number> = {
+        "UNKNOWN": 0,
+        "LOW": 0,
+        "MEDIUM": 0,
+        "HIGH": 0,
+        "CRITICAL": 0
+      };
+
+      // Read the scan file in chunks to avoid buffer overflow issues with large files
+      // The Docker Extension SDK has stdout buffer limits (~200KB) which fail for images
+      // with many vulnerabilities. We work around this by reading the file in chunks.
+      let allContent = "";
+      let lineNum = 1;
+      const chunkSize = 1000; // Read 1000 lines at a time
+
+      while (true) {
+        try {
+          const chunk = await ddClient.docker.cli.exec("run", [
+            "--rm",
+            "-v",
+            "copa-extension-volume:/data",
+            "busybox",
+            "sed",
+            "-n",
+            `${lineNum},${lineNum + chunkSize - 1}p`,
+            "/data/" + JSON_FILE_NAME
+          ]);
+
+          if (!chunk.stdout || chunk.stdout.length === 0) {
+            break; // End of file reached
+          }
+
+          allContent += chunk.stdout;
+          lineNum += chunkSize;
+        } catch (err) {
+          break; // End of file or error
+        }
+      }
+
+      // Parse JSON and count vulnerabilities
+      const data = JSON.parse(allContent);
+
+      if (data.Results) {
+        for (const result of data.Results) {
+          if (result.Vulnerabilities) {
+            for (const vulnerability of result.Vulnerabilities) {
+              const sev = vulnerability.Severity || "UNKNOWN";
+              severityMap[sev]++;
+            }
           }
         }
       }
+
+      setVulnerabilityCount(severityMap);
+      setVulnState(VULN_LOADED);
+    } catch (error) {
+      console.error("Failed to get Trivy output:", error);
+      setVulnState(VULN_UNLOADED);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      ddClient.desktopUI.toast.error(`Failed to parse scan results: ${errorMessage}`);
     }
-    setVulnerabilityCount(severityMap);
-    setVulnState(VULN_LOADED);
   };
 
   // -- Effects --
@@ -301,10 +331,10 @@ export function App() {
             }
             setTotalOutput(tOutput);
           },
-          onClose(exitCode: number) {
+          async onClose(exitCode: number) {
             if (exitCode == 0) {
               ddClient.desktopUI.toast.success(`Trivy scan finished`);
-              getTrivyOutput();
+              await getTrivyOutput();
             } else if (exitCode !== 137) {
               setVulnState(VULN_UNLOADED);
               ddClient.desktopUI.toast.error(`Trivy scan failed: ${stderr}`);

--- a/ui/src/copainput.tsx
+++ b/ui/src/copainput.tsx
@@ -189,6 +189,142 @@ export function CopaInput(props: any) {
                 props.setSelectedTimeout(event.target.value);
               }}
             />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={props.pushToRegistry}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    props.setPushToRegistry(event.target.checked);
+                  }}
+                />
+              }
+              label="Push to registry after patching"
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={props.exitOnEol}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    props.setExitOnEol(event.target.checked);
+                  }}
+                />
+              }
+              label="Exit on End-of-Life OS detection"
+            />
+            <TextField
+              id="eol-api-url-input"
+              label="EOL API URL (optional)"
+              placeholder="https://endoflife.date/api/v1/products"
+              value={props.eolApiUrl === "default" ? "" : props.eolApiUrl}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                props.setEolApiUrl(event.target.value || "default");
+              }}
+              helperText="Leave empty to use default EOL API"
+            />
+            <FormControl fullWidth>
+              <InputLabel id="platform-select-label">Platform</InputLabel>
+              <Select
+                labelId="platform-select-label"
+                id="platform-select"
+                value={props.selectedPlatform}
+                label="Platform"
+                onChange={(event: SelectChangeEvent) => {
+                  props.setSelectedPlatform(event.target.value as string);
+                }}
+              >
+                <MenuItem value="all">All platforms</MenuItem>
+                <MenuItem value="linux/amd64">linux/amd64</MenuItem>
+                <MenuItem value="linux/arm64">linux/arm64</MenuItem>
+                <MenuItem value="linux/arm/v7">linux/arm/v7</MenuItem>
+                <MenuItem value="linux/arm/v6">linux/arm/v6</MenuItem>
+                <MenuItem value="linux/386">linux/386</MenuItem>
+                <MenuItem value="linux/ppc64le">linux/ppc64le</MenuItem>
+                <MenuItem value="linux/s390x">linux/s390x</MenuItem>
+                <MenuItem value="linux/riscv64">linux/riscv64</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={props.ignoreErrors}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    props.setIgnoreErrors(event.target.checked);
+                  }}
+                />
+              }
+              label="Ignore errors (continue patching on failure)"
+            />
+            <FormControl fullWidth>
+              <InputLabel id="progress-select-label">Progress Display</InputLabel>
+              <Select
+                labelId="progress-select-label"
+                id="progress-select"
+                value={props.progressMode}
+                label="Progress Display"
+                onChange={(event: SelectChangeEvent) => {
+                  props.setProgressMode(event.target.value as string);
+                }}
+              >
+                <MenuItem value="auto">Auto</MenuItem>
+                <MenuItem value="plain">Plain</MenuItem>
+                <MenuItem value="tty">TTY</MenuItem>
+                <MenuItem value="quiet">Quiet</MenuItem>
+                <MenuItem value="rawjson">Raw JSON</MenuItem>
+              </Select>
+            </FormControl>
+            <Divider />
+            <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
+              v0.12.0 Features
+            </Typography>
+            <TextField
+              id="oci-dir-input"
+              label="OCI Directory (optional)"
+              placeholder="/path/to/oci/layout"
+              value={props.ociDir}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                props.setOciDir(event.target.value);
+              }}
+              helperText="Local directory for OCI layout (for multi-platform local patching)"
+            />
+            <FormControl fullWidth>
+              <InputLabel id="pkg-types-select-label">Package Types</InputLabel>
+              <Select
+                labelId="pkg-types-select-label"
+                id="pkg-types-select"
+                value={props.pkgTypes}
+                label="Package Types"
+                onChange={(event: SelectChangeEvent) => {
+                  props.setPkgTypes(event.target.value as string);
+                }}
+              >
+                <MenuItem value="os">OS packages only</MenuItem>
+                <MenuItem value="library">Library packages only (Experimental)</MenuItem>
+                <MenuItem value="os,library">OS + Library packages (Experimental)</MenuItem>
+              </Select>
+            </FormControl>
+            {(props.pkgTypes === "library" || props.pkgTypes === "os,library") && (
+              <Stack spacing={1}>
+                <FormControl fullWidth>
+                  <InputLabel id="library-patch-level-select-label">Library Patch Level</InputLabel>
+                  <Select
+                    labelId="library-patch-level-select-label"
+                    id="library-patch-level-select"
+                    value={props.libraryPatchLevel}
+                    label="Library Patch Level"
+                    onChange={(event: SelectChangeEvent) => {
+                      props.setLibraryPatchLevel(event.target.value as string);
+                    }}
+                  >
+                    <MenuItem value="patch">Patch (most conservative)</MenuItem>
+                    <MenuItem value="minor">Minor (allow minor updates)</MenuItem>
+                    <MenuItem value="major">Major (allow breaking changes)</MenuItem>
+                  </Select>
+                </FormControl>
+                <Typography variant="caption" color="warning.main" sx={{ fontStyle: 'italic' }}>
+                  ⚠️ App-level patching is experimental. Supports Python and Node.js packages.
+                </Typography>
+              </Stack>
+            )}
           </Stack>
         </Grow>
       </Collapse>


### PR DESCRIPTION
Added

  - Support for Copa v0.12.0
  - New flags: --push, --exit-on-eol, --eol-api-url, --platform, --ignore-errors, --progress, --oci-dir, --pkg-types, --library-patch-level
  - Experimental Python and Node.js package patching
  - Settings UI for all new flags

  Changed

  - Default Copa version: v0.7.0 → v0.12.0
  - Trivy flags: --vuln-type os → --pkg-types os (fixes #85)
  - Added --scanners vuln to Trivy command